### PR TITLE
Fix missing variables in the header

### DIFF
--- a/sut-te-bridge/ros2_bridge_ws/src/sut_te_bridge/include/bridge.h
+++ b/sut-te-bridge/ros2_bridge_ws/src/sut_te_bridge/include/bridge.h
@@ -127,6 +127,8 @@ namespace bridge
         bool raptorDataAvailabe = false;
         bool useCustomRaceControl = false;
         bool verbosePrinting = false;
+        bool stackFeedbackConnectionWarningSent = false;
+        bool stackRaptorConnectionWarningSent = false;
         bool simModeEnabled = false;
         bool numberWarningSent = false;
         uint8_t prestart_rolling_counter;


### PR DESCRIPTION
`main` throws a compile error due to the missing variables
```
        bool stackFeedbackConnectionWarningSent = false;
        bool stackRaptorConnectionWarningSent = false;
```
