### PR TITLE
ROS2 Interfacing Improvements

### DIFF
--- a/Dockerfile_Sensor_Bridge
+++ b/Dockerfile_Sensor_Bridge
@@ -41,7 +41,6 @@ ENTRYPOINT ["tail", "-f", "/dev/null"]
 FROM sensor-bridge_base AS sensor-bridge_simphera
 # Build bridge node and enable autostart for headless execution
 COPY sensor-bridge/ros2_bridge_ws /root/ros2_bridge_ws
-COPY sensor-bridge/runtime_scripts /root/runtime_scripts
 RUN mkdir -p /root/record_log && \
     source /opt/ros/humble/local_setup.bash && \
     source /root/ros_ws_aux/install/local_setup.bash && \

--- a/Dockerfile_Sensor_Bridge
+++ b/Dockerfile_Sensor_Bridge
@@ -3,7 +3,6 @@ FROM ros:humble-ros-base AS dspace_ros_base
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["tail", "-f", "/dev/null"]
 
-ENV LD_LIBRARY_PATH=/opt/VESI/lib
 ENV SIM_CLOCK_MODE=false
 ENV ENABLE_LOG=false
 
@@ -12,11 +11,6 @@ RUN apt-get update && \
 
 RUN rosdep update && \
     echo 'source /opt/ros/humble/local_setup.bash' >> /root/.bashrc
-
-RUN mkdir -p /opt/VESI/lib 
-COPY sensor-bridge/ros2_bridge_ws/src/sensor_bridge/include/V-ESI-API/lib/linux/libVESIAPI.so /opt/VESI/lib/
-
-RUN ldconfig
 
 FROM dspace_ros_base AS sensor-bridge_base 
 # Build bridge message definitions to enable dev working environment

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(geometry_msgs REQUIRED)
 find_package(autonoma_msgs REQUIRED)
 find_package(vectornav_msgs REQUIRED)
 find_package(novatel_oem7_msgs REQUIRED)
-find_package(npc_controller_msgs REQUIRED)
 find_package(foxglove_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -33,7 +32,6 @@ set(MSG_DEPS geometry_msgs)
 set(MSG_DEPS autonoma_msgs)
 set(MSG_DEPS vectornav_msgs)
 set(MSG_DEPS novatel_oem7_msgs)
-set(MSG_DEPS npc_controller_msgs)
 set(MSG_DEPS rosgraph_msgs)
 
 include_directories(
@@ -49,7 +47,6 @@ set(dependencies
   autonoma_msgs
   vectornav_msgs
   novatel_oem7_msgs
-  npc_controller_msgs
   foxglove_msgs
   rosgraph_msgs
 )

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
@@ -75,5 +75,17 @@ install(TARGETS ${exe_name}
   DESTINATION lib/${PROJECT_NAME}
 )
 
+# Install the VESI API library into the install directory
+install(FILES
+  ${VESIAPI_DIR}/lib/linux/libVESIAPI.so
+  DESTINATION lib
+)
+
+# Runtime link the VESI API path (rather than a static path)
+set_target_properties(
+  ${exe_name} PROPERTIES
+  INSTALL_RPATH "$ORIGIN/.."
+)
+
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
@@ -74,9 +74,6 @@ target_include_directories(${exe_name}
 install(TARGETS ${exe_name}
   DESTINATION lib/${PROJECT_NAME}
 )
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/CMakeLists.txt
@@ -10,9 +10,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_C_STANDARD 99)
 
-include_directories(/opt/ros/humble/include/tf2)
-include_directories(/opt/ros/humble/include/tf2_ros)
-
 # find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -24,6 +21,8 @@ find_package(novatel_oem7_msgs REQUIRED)
 find_package(foxglove_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 find_package(OpenMP REQUIRED)
 
 set(MSG_DEPS std_msgs)
@@ -49,6 +48,8 @@ set(dependencies
   novatel_oem7_msgs
   foxglove_msgs
   rosgraph_msgs
+  tf2
+  tf2_ros
 )
 
 install(DIRECTORY include/

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/package.xml
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/package.xml
@@ -16,7 +16,6 @@
   <depend>autonoma_msgs</depend>
   <depend>vectornav_msgs</depend>
   <depend>novatel_oem7_msgs</depend>
-  <depend>npc_controller_msgs</depend>
   <depend>foxglove_msgs</depend>
   <depend>rosgraph_msgs</depend>
 

--- a/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/package.xml
+++ b/sensor-bridge/ros2_bridge_ws/src/sensor_bridge/package.xml
@@ -18,6 +18,8 @@
   <depend>novatel_oem7_msgs</depend>
   <depend>foxglove_msgs</depend>
   <depend>rosgraph_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
A few improvements on the ROS2 side of things to help run the scripts outside the docker environment

- Fixes a few build issues in the sensor bridge docker and ros2 package 
- Removes unused dependencies in the sensor bridge
- Install and link VESI API library via CMakeLists rather than dockerfile
  - Double check this one works on your side as I don't have the set up to check it
- Use `tf2` and `tf2_ros` packages rather than directly linking install directories 